### PR TITLE
Add Sprint 1 Kanban plan, repo governance and GitHub issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,29 @@
+---
+name: "Bug"
+about: "Reporte de incidencia"
+title: "[BUG] "
+labels: ["bug"]
+assignees: []
+---
+
+## Descripción del bug
+Explica qué falla y en qué contexto.
+
+## Pasos para reproducir
+1.
+2.
+3.
+
+## Resultado esperado
+Qué debería ocurrir.
+
+## Resultado actual
+Qué ocurre realmente.
+
+## Severidad
+- [ ] Baja
+- [ ] Media
+- [ ] Alta
+
+## Evidencias
+Logs, capturas, traceback, enlace de ejecución.

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,26 @@
+---
+name: "Epic"
+about: "Iniciativa de alto nivel que agrupa subtareas"
+title: "[EPIC] "
+labels: ["epic"]
+assignees: []
+---
+
+## Objetivo de negocio/técnico
+Qué problema resuelve esta épica y por qué importa en Sprint 1.
+
+## Resultado esperado
+Entregables medibles al cerrar la épica.
+
+## Subtareas
+- [ ] #<issue-subtask-1>
+- [ ] #<issue-subtask-2>
+- [ ] #<issue-subtask-3>
+
+## Criterios de aceptación de la épica
+- [ ] Todos los issues dependientes cerrados.
+- [ ] Documentación principal actualizada.
+- [ ] Demo funcional disponible.
+
+## Riesgos
+Bloqueos o dependencias externas.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,28 @@
+---
+name: "Task"
+about: "Tarea técnica o funcional para Sprint"
+title: "[TASK] "
+labels: ["task"]
+assignees: []
+---
+
+## Contexto
+Describe el problema o necesidad.
+
+## Objetivo
+Resultado concreto esperado.
+
+## Alcance
+- Incluye:
+- No incluye:
+
+## Criterios de aceptación
+- [ ] Criterio 1
+- [ ] Criterio 2
+- [ ] Criterio 3
+
+## Dependencias
+Issues o PRs relacionados.
+
+## Evidencias esperadas
+Capturas, logs, notebook, outputs, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Resumen
+Qué cambia y por qué.
+
+## Tipo de cambio
+- [ ] feature
+- [ ] fix
+- [ ] refactor
+- [ ] docs
+- [ ] chore
+
+## Evidencias
+- Capturas / outputs / enlaces.
+
+## Checklist DoD
+- [ ] Cumple criterios de aceptación del issue.
+- [ ] Tests/checks ejecutados localmente.
+- [ ] Documentación actualizada.
+- [ ] Sin secretos ni credenciales.
+- [ ] Reviewer asignado.
+
+## Riesgos e impacto
+Dependencias técnicas, rollback y/o consideraciones de despliegue.
+
+## Issues relacionados
+Closes #...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+# AGENTS.md — Reglas operativas del repositorio DEPORTEData
+
+## Objetivo
+Este repositorio implementa el proyecto universitario **DEPORTEData** para el **Reto A**.
+El objetivo operativo es trabajar con un flujo profesional de planificación, desarrollo y entrega por sprints.
+
+## Metodología y organización
+- Marco: **Scrum ligero** con sprints semanales.
+- Gestión diaria: tablero **Kanban** en GitHub Projects.
+- Equipos/roles: `frontend`, `backend`, `ia`, `devops`.
+- Todo el trabajo debe estar trazado mediante **Issue -> PR -> Merge**.
+
+## Estructura de trabajo recomendada
+- Épicas para objetivos de alto nivel.
+- Subtareas para trabajo ejecutable de corta duración.
+- Sprint 1 orientado a:
+  1. definición analítica,
+  2. catálogo de fuentes,
+  3. base de ingestión,
+  4. diseño de modelo en estrella,
+  5. gobierno técnico (plantillas, CI y flujo Git).
+
+## Flujo de ramas (GitHub Flow simplificado)
+- `main`: rama protegida de publicación/estable.
+- `develop`: rama de integración del sprint.
+- `feature/<area>-<short-name>`: desarrollo por issue.
+- `hotfix/<short-name>`: correcciones críticas.
+
+### Reglas de merge
+1. No se permite push directo a `main` ni `develop`.
+2. Todo cambio debe llegar por PR desde `feature/*` hacia `develop`.
+3. `develop` solo pasa a `main` en cierre de sprint/release.
+4. Requiere al menos 1 aprobación (2 para infraestructura/seguridad).
+5. CI obligatoria en verde para merge.
+6. Método preferido: **Squash and merge**.
+
+## Convenciones de issues y PR
+- Usar plantillas en `.github/ISSUE_TEMPLATE/`.
+- Toda issue debe incluir criterios de aceptación verificables.
+- Toda PR debe incluir:
+  - resumen,
+  - tipo de cambio,
+  - checklist DoD,
+  - issues relacionados (`Closes #...`),
+  - evidencias (logs/capturas/enlaces).
+
+## Definition of Done (DoD)
+Una tarea se considera terminada cuando:
+1. Cumple criterios de aceptación.
+2. Tiene PR mergeada en `develop`.
+3. Incluye documentación actualizada cuando aplique.
+4. Pasa checks mínimos de calidad.
+5. Mantiene trazabilidad completa (issue/PR/evidencia).
+
+## Etiquetas recomendadas
+- Tipo: `epic`, `task`, `bug`, `chore`, `docs`.
+- Sprint: `sprint-1`, `sprint-2`, etc.
+- Dominio: `frontend`, `backend`, `ia`, `devops`, `data-model`, `analytics`, `governance`.
+- Prioridad: `priority:high`, `priority:medium`, `priority:low`.
+
+## Kanban recomendado
+Columnas:
+1. Backlog
+2. Ready
+3. In Progress
+4. In Review
+5. Blocked
+6. Done (Sprint)
+
+## Calidad y seguridad
+- Prohibido subir secretos o credenciales.
+- Mantener `.env.example` y usar gestores seguros de configuración.
+- Documentar riesgos, supuestos y limitaciones analíticas.
+- En análisis: no confundir correlación con causalidad.
+
+## Documentación mínima esperada
+- README actualizado.
+- Catálogo de fuentes y trazabilidad.
+- Diseño del modelo en estrella.
+- Evidencias de validación y decisiones técnicas.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # DEPORTEData
+
+Repositorio base del proyecto universitario **DEPORTEData**.
+
+## Gestión de proyecto
+- Plan de Sprint 1 y Kanban: `docs/SPRINT1_KANBAN_PLAN.md`
+- Reglas operativas del repositorio: `AGENTS.md`
+- Plantillas de trabajo:
+  - Issues: `.github/ISSUE_TEMPLATE/`
+  - Pull Requests: `.github/pull_request_template.md`

--- a/docs/SPRINT1_KANBAN_PLAN.md
+++ b/docs/SPRINT1_KANBAN_PLAN.md
@@ -1,0 +1,327 @@
+# DEPORTEData · Sprint 1 Kanban Plan (Reto A)
+
+## Contexto operativo
+- Proyecto: **DEPORTEData**.
+- Reto elegido: **Reto A** (gasto por hogar vs práctica federada por CCAA).
+- Duración sprint: **1 semana**.
+- Metodología: **Scrum ligero + Kanban operativo**.
+- Equipo: frontend, backend, IA y devops.
+
+---
+
+## 1) Estructura de backlog para Sprint 1
+
+### ÉPICA E1 — Definición del problema, hipótesis y KPIs
+**Objetivo**: aterrizar el reto A en preguntas analíticas medibles.
+
+Subtareas:
+1. Definir pregunta principal y preguntas secundarias.
+2. Formular 3–5 hipótesis verificables.
+3. Definir KPIs mínimos (gasto hogar, práctica federada, variación interanual, correlación inicial).
+4. Establecer glosario de métricas y supuestos.
+
+---
+
+### ÉPICA E2 — Catálogo y trazabilidad de fuentes oficiales
+**Objetivo**: identificar y documentar datasets descargables sin scraping.
+
+Subtareas:
+1. Selección de fuentes oficiales (INE, CSD, ministerios, portales abiertos).
+2. Registro de licencia, periodicidad, granularidad y cobertura.
+3. Descarga de datasets en `data/raw/`.
+4. Diccionario inicial de campos por fuente.
+
+---
+
+### ÉPICA E3 — Base técnica de ingestión y estructura del repositorio
+**Objetivo**: dejar el proyecto listo para desarrollar con flujo reproducible.
+
+Subtareas:
+1. Estructura de carpetas (`src/`, `data/`, `notebooks/`, `docs/`, `infra/`).
+2. Script de ingestión base y validación de esquema inicial.
+3. Versionado de dependencias y `.env.example`.
+4. Convenciones de logging y gestión de errores.
+
+---
+
+### ÉPICA E4 — Diseño preliminar del modelo analítico en estrella
+**Objetivo**: definir modelo lógico para hechos/dimensiones del reto A.
+
+Subtareas:
+1. Definir tabla de hechos `hechos_indicadores`.
+2. Definir dimensiones `dim_tiempo`, `dim_geografia`, `dim_indicador`, `dim_fuente`.
+3. Proponer claves y reglas de integridad.
+4. Entregar diagrama (Mermaid o draw.io exportado).
+
+---
+
+### ÉPICA E5 — Entorno de trabajo, CI mínima y definición de DoD
+**Objetivo**: reducir fricción de equipo desde Sprint 1.
+
+Subtareas:
+1. Configurar workflow CI básico (lint + tests smoke).
+2. Definir Definition of Done para issues.
+3. Configurar plantillas de issue/PR.
+4. Definir normas de ramas y revisión.
+
+---
+
+## 2) Lista de issues propuestas (épicas y subtareas)
+
+> Formato: **Título · Descripción · Criterios de aceptación · Etiquetas · Responsable sugerido**.
+
+### EPIC-01 · Definición analítica del Reto A
+**Descripción**: consolidar alcance analítico de Sprint 1 y documentar hipótesis del equipo.
+
+**Criterios de aceptación**:
+- Documento de alcance en `docs/` publicado.
+- Pregunta principal + al menos 3 preguntas secundarias.
+- 3–5 hipótesis con posible método de validación.
+
+**Etiquetas**: `epic`, `sprint-1`, `analytics`, `reto-a`
+
+**Responsable sugerido**: IA (co-lidera con backend)
+
+#### Subtareas
+1. **[S1-A1] Redactar marco de hipótesis iniciales del Reto A**
+   - Criterios: hipótesis medibles + variable dependiente/independiente.
+   - Etiquetas: `task`, `analytics`, `ia`, `sprint-1`
+   - Responsable: IA
+
+2. **[S1-A2] Definir KPIs analíticos mínimos del sprint**
+   - Criterios: al menos 4 KPIs con fórmula y fuente.
+   - Etiquetas: `task`, `analytics`, `backend`, `sprint-1`
+   - Responsable: Backend
+
+---
+
+### EPIC-02 · Catálogo de fuentes y trazabilidad
+**Descripción**: construir inventario oficial de fuentes con trazabilidad y metadatos.
+
+**Criterios de aceptación**:
+- Fichero `docs/sources_catalog.md` creado.
+- Cada fuente incluye URL, licencia, rango temporal, cobertura geográfica, formato.
+- Datasets descargados a `data/raw/` con naming estándar.
+
+**Etiquetas**: `epic`, `data`, `sprint-1`, `reto-a`
+
+**Responsable sugerido**: Backend
+
+#### Subtareas
+1. **[S1-B1] Identificar fuentes oficiales para gasto por hogar**
+   - Criterios: mínimo 2 fuentes candidatas con justificación.
+   - Etiquetas: `task`, `data`, `backend`, `sprint-1`
+   - Responsable: Backend
+
+2. **[S1-B2] Identificar fuentes oficiales de práctica federada por CCAA**
+   - Criterios: mínimo 2 fuentes candidatas con detalle territorial.
+   - Etiquetas: `task`, `data`, `ia`, `sprint-1`
+   - Responsable: IA
+
+3. **[S1-B3] Descargar y versionar dataset raw inicial**
+   - Criterios: archivos en `data/raw/` + README de procedencia.
+   - Etiquetas: `task`, `data-engineering`, `backend`, `sprint-1`
+   - Responsable: Backend
+
+---
+
+### EPIC-03 · Base técnica del repositorio y pipeline de ingestión
+**Descripción**: crear base de código para ingestión reproducible y estructura de trabajo.
+
+**Criterios de aceptación**:
+- Estructura estándar de directorios creada.
+- Script ejecutable de ingestión inicial.
+- Dependencias y configuración base documentadas.
+
+**Etiquetas**: `epic`, `backend`, `devops`, `sprint-1`
+
+**Responsable sugerido**: Backend
+
+#### Subtareas
+1. **[S1-C1] Crear estructura base del proyecto y convenciones**
+   - Criterios: árbol de carpetas + README actualizado.
+   - Etiquetas: `task`, `backend`, `documentation`, `sprint-1`
+   - Responsable: Backend
+
+2. **[S1-C2] Implementar script `ingest_raw.py` (MVP)**
+   - Criterios: descarga/copia raw + validación básica de columnas.
+   - Etiquetas: `task`, `data-engineering`, `backend`, `sprint-1`
+   - Responsable: Backend
+
+3. **[S1-C3] Definir `.env.example` y parámetros de entorno**
+   - Criterios: variables obligatorias documentadas.
+   - Etiquetas: `task`, `devops`, `sprint-1`
+   - Responsable: DevOps
+
+---
+
+### EPIC-04 · Modelo analítico preliminar en estrella
+**Descripción**: definir diseño lógico inicial para hechos y dimensiones del reto.
+
+**Criterios de aceptación**:
+- Diagrama del modelo en `docs/`.
+- Definición de PK/FK y granularidad.
+- Supuestos y riesgos de modelado identificados.
+
+**Etiquetas**: `epic`, `data-model`, `sprint-1`, `reto-a`
+
+**Responsable sugerido**: IA
+
+#### Subtareas
+1. **[S1-D1] Diseñar tabla de hechos y granularidad**
+   - Criterios: grano explícito (anio-ccaa-indicador-fuente).
+   - Etiquetas: `task`, `data-model`, `ia`, `sprint-1`
+   - Responsable: IA
+
+2. **[S1-D2] Diseñar dimensiones y diccionario de campos**
+   - Criterios: dimensiones mínimas documentadas con tipos.
+   - Etiquetas: `task`, `data-model`, `backend`, `sprint-1`
+   - Responsable: Backend
+
+---
+
+### EPIC-05 · Operación del equipo: flujo GitHub + CI + calidad
+**Descripción**: establecer reglas de colaboración, revisión y despliegue mínimo seguro.
+
+**Criterios de aceptación**:
+- Plantillas de issue y PR activas.
+- Reglas de ramas y merge documentadas.
+- CI básica ejecutándose en PR.
+
+**Etiquetas**: `epic`, `devops`, `governance`, `sprint-1`
+
+**Responsable sugerido**: DevOps
+
+#### Subtareas
+1. **[S1-E1] Configurar issue templates (bug/task/epic)**
+   - Criterios: plantillas funcionales en `.github/ISSUE_TEMPLATE/`.
+   - Etiquetas: `task`, `devops`, `documentation`, `sprint-1`
+   - Responsable: DevOps
+
+2. **[S1-E2] Crear plantilla de Pull Request**
+   - Criterios: checklist DoD + impacto + evidencias.
+   - Etiquetas: `task`, `devops`, `documentation`, `sprint-1`
+   - Responsable: DevOps
+
+3. **[S1-E3] Definir branch policy y estrategia de merge**
+   - Criterios: documento publicado y compartido al equipo.
+   - Etiquetas: `task`, `governance`, `devops`, `sprint-1`
+   - Responsable: DevOps
+
+---
+
+## 3) Separación épicas vs subtareas
+
+- Las **épicas** agrupan resultados de negocio/técnicos de alto nivel para Sprint 1.
+- Las **subtareas** son unidades ejecutables de 0.5 a 1.5 días, asignables a una persona.
+- Regla: una subtarea no debe mezclar dos dominios (ej. ingestión + dashboard).
+
+---
+
+## 4) Columnas propuestas del Kanban (GitHub Projects)
+
+1. **Backlog**: todo lo no comprometido.
+2. **Ready**: issue refinado con criterios y responsable.
+3. **In Progress**: trabajo activo (WIP limitado por rol).
+4. **In Review**: PR abierto con reviewer asignado.
+5. **Blocked**: dependencia externa o impedimento.
+6. **Done (Sprint)**: mergeado y validado en `develop`.
+
+Sugerencia WIP:
+- Frontend: 2
+- Backend: 3
+- IA: 2
+- DevOps: 2
+
+---
+
+## 5) Plantillas propuestas
+
+### 5.1 Plantilla de Issue (Task)
+```md
+## Contexto
+Describe el problema o necesidad.
+
+## Objetivo
+Resultado concreto esperado.
+
+## Alcance
+- Incluye:
+- No incluye:
+
+## Criterios de aceptación
+- [ ] Criterio 1
+- [ ] Criterio 2
+- [ ] Criterio 3
+
+## Dependencias
+Issues o PRs relacionados.
+
+## Evidencias esperadas
+Capturas, logs, notebook, outputs, etc.
+```
+
+### 5.2 Plantilla de Pull Request
+```md
+## Resumen
+Qué cambia y por qué.
+
+## Tipo de cambio
+- [ ] feature
+- [ ] fix
+- [ ] refactor
+- [ ] docs
+- [ ] chore
+
+## Evidencias
+- Capturas / outputs / enlaces.
+
+## Checklist DoD
+- [ ] Cumple criterios de aceptación del issue.
+- [ ] Tests/checks ejecutados localmente.
+- [ ] Documentación actualizada.
+- [ ] Sin secretos ni credenciales.
+- [ ] Reviewer asignado.
+
+## Issues relacionados
+Closes #...
+```
+
+---
+
+## 6) Normas de ramas y merges (GitHub Flow simplificado)
+
+### Ramas
+- `main`: protegida, solo producción estable.
+- `develop`: integración del sprint.
+- `feature/<area>-<short-name>`: trabajo de cada issue.
+- `hotfix/<short-name>`: correcciones urgentes.
+
+### Reglas de merge
+1. Nunca push directo a `main` ni `develop`.
+2. Todo cambio entra por PR desde `feature/*` -> `develop`.
+3. `develop` -> `main` solo en cierre de sprint/release.
+4. Mínimo 1 aprobación de reviewer (2 si toca infra/seguridad).
+5. CI en verde obligatoria antes de merge.
+6. Merge preferido: **Squash and merge** para mantener historial limpio.
+7. Commits con convención sugerida: `feat:`, `fix:`, `docs:`, `chore:`.
+
+---
+
+## 7) Definition of Done (DoD) para Sprint 1
+
+Una issue se considera terminada cuando:
+1. Cumple todos sus criterios de aceptación.
+2. Tiene PR mergeada en `develop`.
+3. Incluye actualización documental si aplica.
+4. Pasa checks automáticos mínimos.
+5. Queda trazabilidad (issue + PR + evidencia).
+
+---
+
+## Recomendación de arranque del Sprint 1 (día 1)
+1. Crear proyecto Kanban en GitHub con columnas propuestas.
+2. Cargar las 5 épicas y sus subtareas.
+3. Etiquetar por rol (`frontend`, `backend`, `ia`, `devops`).
+4. Asignar responsables y estimación rápida (S/M/L).
+5. Arrancar con EPIC-02 y EPIC-03 en paralelo.


### PR DESCRIPTION
### Motivation
- Provide a clear, professional Sprint 1 plan and operational rules so the team (frontend/backend/IA/devops) can start work on Reto A with shared conventions and traceability. 
- Standardize issue/PR templates, branch rules and DoD to reduce friction in reviews and ensure minimal CI/quality checks are applied from day one.

### Description
- Add `docs/SPRINT1_KANBAN_PLAN.md` containing backlog structure, five épicas with subtasks, Kanban columns, WIP suggestions and recommended kickoff steps. 
- Add `AGENTS.md` at repo root documenting methodology, branch flow (`main`/`develop`/`feature/*`), merge rules, DoD, label taxonomy and security/good-practice notes. 
- Add GitHub templates under `.github/ISSUE_TEMPLATE/` for `task`, `epic` and `bug`, and add a `pull_request_template.md` to standardize PR content and DoD checklist. 
- Update `README.md` to reference the new planning and governance documents and the templates location.

### Testing
- Verified the new files exist and are readable using repository checks with `rg --files`, which listed the added documentation. 
- Verified working tree status with `git status --short` to ensure no untracked or missing files remained after adding the artifacts. 
- Printed file contents with `nl -ba` for `README.md`, `AGENTS.md`, `docs/SPRINT1_KANBAN_PLAN.md` and the new templates to confirm the expected sections and templates are present and formatted; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae5a3ec508326b631fbf9695ceb67)