### PR TITLE
fix(frontend): habilitar build y despliegue en Vercel

### DIFF
--- a/backend/app/models_request.py
+++ b/backend/app/models_request.py
@@ -7,4 +7,4 @@ class LoginRequest(BaseModel):
 
 
 class ChatRequest(BaseModel):
-    question: str
+    message: str

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,4 @@
+VITE_API_BASE_URL=https://deporte-data-backend.onrender.com
 VITE_PUBLIC_DASHBOARD_URL=https://grafana.example.com/public-dashboard
 VITE_ADMIN_HOME_DASHBOARD_URL=https://grafana.example.com/admin-home
 VITE_ADMIN_TELEMETRY_DASHBOARD_URL=https://grafana.example.com/telemetrias

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,55 @@
+export type DashboardPoint = {
+  year: number;
+  value: number;
+};
+
+export type DashboardSeries = DashboardPoint[];
+
+export type DashboardKpis = {
+  empleo_total: number;
+  growth_pct: number;
+  latest_year: number;
+  latest_values: DashboardPoint[];
+};
+
+export type ChatResponse = {
+  message: string;
+  answer: string;
+};
+
+const rawBaseUrl = import.meta.env.VITE_API_BASE_URL as string | undefined;
+const normalizedBaseUrl = rawBaseUrl?.replace(/\/+$/, '');
+
+const baseUrl = normalizedBaseUrl && /^https?:\/\//.test(normalizedBaseUrl)
+  ? normalizedBaseUrl
+  : '/api';
+
+async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(errorText || `Request failed with status ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export const dashboardApi = {
+  getKpis: () => requestJson<DashboardKpis>('/dashboard/kpis'),
+  getSeries: () => requestJson<DashboardSeries>('/dashboard/series'),
+};
+
+export const chatApi = {
+  sendMessage: (message: string) =>
+    requestJson<ChatResponse>('/chat', {
+      method: 'POST',
+      body: JSON.stringify({ message }),
+    }),
+};

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
-  "installCommand": "npm ci",
+  "installCommand": "npm install",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "rewrites": [

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [
+    {
+      "source": "/api/(.*)",
+      "destination": "https://deporte-data-backend.onrender.com/$1"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/vercel-build.sh
+++ b/vercel-build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ -f package.json ]; then
+  npm run build
+  rm -rf .vercel-dist
+  cp -R dist .vercel-dist
+elif [ -f frontend/package.json ]; then
+  cd frontend
+  npm run build
+  rm -rf ../.vercel-dist
+  cp -R dist ../.vercel-dist
+elif [ -f ../frontend/package.json ]; then
+  cd ../frontend
+  npm run build
+  rm -rf ../backend/.vercel-dist
+  cp -R dist ../backend/.vercel-dist
+else
+  echo "No frontend package.json found"
+  exit 1
+fi

--- a/vercel-install.sh
+++ b/vercel-install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ -f package.json ]; then
+  npm install
+elif [ -f frontend/package.json ]; then
+  cd frontend
+  npm install
+elif [ -f ../frontend/package.json ]; then
+  cd ../frontend
+  npm install
+else
+  echo "No frontend package.json found"
+  exit 1
+fi

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
-  "installCommand": "cd frontend && npm ci",
-  "buildCommand": "cd frontend && npm run build",
-  "outputDirectory": "frontend/dist",
+  "installCommand": "if [ -d frontend ]; then cd frontend && npm ci; else npm ci; fi",
+  "buildCommand": "if [ -d frontend ]; then cd frontend && npm run build && cp -R dist ../dist; else npm run build; fi",
+  "outputDirectory": "dist",
   "rewrites": [
     {
       "source": "/api/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
-  "installCommand": "if [ -f package.json ]; then npm install; elif [ -f frontend/package.json ]; then cd frontend && npm install; elif [ -f ../frontend/package.json ]; then cd ../frontend && npm install; else echo 'No frontend package.json found' && exit 1; fi",
-  "buildCommand": "if [ -f package.json ]; then npm run build && cp -R dist .vercel-dist; elif [ -f frontend/package.json ]; then cd frontend && npm run build && cp -R dist ../.vercel-dist; elif [ -f ../frontend/package.json ]; then cd ../frontend && npm run build && cp -R dist ../backend/.vercel-dist; else echo 'No frontend package.json found' && exit 1; fi",
+  "installCommand": "if [ -f ./vercel-install.sh ]; then sh ./vercel-install.sh; else sh ../vercel-install.sh; fi",
+  "buildCommand": "if [ -f ./vercel-build.sh ]; then sh ./vercel-build.sh; else sh ../vercel-build.sh; fi",
   "outputDirectory": ".vercel-dist",
   "rewrites": [
     {

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
-  "installCommand": "if [ -d frontend ]; then cd frontend && npm install; else npm install; fi",
-  "buildCommand": "if [ -d frontend ]; then cd frontend && npm run build && cp -R dist ../dist; else npm run build; fi",
-  "outputDirectory": "dist",
+  "installCommand": "if [ -f package.json ]; then npm install; elif [ -f frontend/package.json ]; then cd frontend && npm install; elif [ -f ../frontend/package.json ]; then cd ../frontend && npm install; else echo 'No frontend package.json found' && exit 1; fi",
+  "buildCommand": "if [ -f package.json ]; then npm run build && cp -R dist .vercel-dist; elif [ -f frontend/package.json ]; then cd frontend && npm run build && cp -R dist ../.vercel-dist; elif [ -f ../frontend/package.json ]; then cd ../frontend && npm run build && cp -R dist ../backend/.vercel-dist; else echo 'No frontend package.json found' && exit 1; fi",
+  "outputDirectory": ".vercel-dist",
   "rewrites": [
     {
       "source": "/api/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "installCommand": "cd frontend && npm ci",
+  "buildCommand": "cd frontend && npm run build",
+  "outputDirectory": "frontend/dist",
+  "rewrites": [
+    {
+      "source": "/api/(.*)",
+      "destination": "https://deporte-data-backend.onrender.com/$1"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
-  "installCommand": "if [ -d frontend ]; then cd frontend && npm ci; else npm ci; fi",
+  "installCommand": "if [ -d frontend ]; then cd frontend && npm install; else npm install; fi",
   "buildCommand": "if [ -d frontend ]; then cd frontend && npm run build && cp -R dist ../dist; else npm run build; fi",
   "outputDirectory": "dist",
   "rewrites": [


### PR DESCRIPTION
### Motivation
- Resolver la falla de compilación causada por imports a un cliente API inexistente y la incompatibilidad del payload del chat entre frontend y backend.
- Permitir un despliegue correcto en Vercel apuntando el build al subdirectorio `frontend` y enrutar las llamadas `/api/*` al backend desplegado.
- Documentar y parametrizar la URL del backend para que el frontend pueda apuntar a la API en entornos de despliegue.

### Description
- Añade `frontend/src/services/api.ts` con tipos y funciones `dashboardApi` y `chatApi` y lógica para leer `VITE_API_BASE_URL` con fallback a `/api`.
- Crea `vercel.json` en la raíz con `installCommand`, `buildCommand`, `outputDirectory` y rewrites para enrutar `/api/(.*)` a `https://deporte-data-backend.onrender.com/$1` y para el fallback SPA a `/index.html`.
- Actualiza `frontend/.env.example` añadiendo `VITE_API_BASE_URL=https://deporte-data-backend.onrender.com` para documentar la variable necesaria en despliegues.
- Ajusta `backend/app/models_request.py` para que `ChatRequest` acepte el campo `message`, alineando el contrato con el frontend.

### Testing
- Ejecuté `cd frontend && npm run build` y la compilación de producción con `vite build` completó correctamente.
- Ejecuté `python -m compileall backend/app` y la compilación de bytecode de Python fue exitosa.
- Verifiqué que `npm run build` produjo el directorio `frontend/dist` sin errores de tipos ni imports fallidos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6c3c328083269e5c3c61e47dacd1)