### PR TITLE
feat(integration): conectar frontend con API unificada del backend y añadir auth

### DIFF
--- a/backend/app/api/routes_public.py
+++ b/backend/app/api/routes_public.py
@@ -1,11 +1,17 @@
 """
 API Pública (:8000) — Endpoints para el frontend.
 
-Endpoints migrados del original:
+Endpoints principales para frontend:
   - GET  /health                → estado del servicio
-  - POST /login                 → autenticación JWT
-  - POST /getResponseChat       → chat (simulado ahora, RAG en Sprint 4)
-  - GET  /getDatosDashboard     → KPIs para dashboard
+  - POST /auth/login            → autenticación JWT
+  - POST /chat                  → chat conectado al dataset limpio
+  - GET  /dashboard/kpis        → KPIs para dashboard
+  - GET  /dashboard/series      → serie temporal para gráfica
+
+Compatibilidad backward (legacy):
+  - POST /login
+  - POST /getResponseChat
+  - GET  /getDatosDashboard
 
 Endpoints de datos:
   - GET  /api/v1/empleo         → consulta empleo deportivo
@@ -14,16 +20,16 @@ Endpoints de datos:
   - GET  /api/v1/s3/list        → listar keys en S3
 """
 
-import random
 import logging
 
-from fastapi import APIRouter, UploadFile, File, Query, HTTPException
+from fastapi import APIRouter, UploadFile, File, Query, HTTPException, Depends
 
 from app.config import get_settings
 from app.models import LoginRequest, ChatRequest
 from app.auth import create_token
 from app.db.connection import fetch_all
 from app.s3_client import upload_bytes, list_keys
+from app.services.data_service import DataService, get_data_service
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["public"])
@@ -39,17 +45,9 @@ TEST_USER = {
     }
 }
 
-RESPUESTAS_SIMULADAS = [
-    "Según la previsión anual, el sector del deporte podría generar un aumento moderado de empleo.",
-    "La estimación del modelo indica que la demanda de empleo deportivo podría crecer.",
-    "La predicción sugiere que el empleo en el sector deportivo tendrá una evolución positiva.",
-    "El modelo prevé que los puestos de trabajo en el ámbito deportivo podrían incrementarse.",
-    "La previsión permite anticipar tendencias de empleo en el deporte.",
-]
-
 
 # ══════════════════════════════════════════════
-# Endpoints migrados del original
+# Endpoints frontend (actuales)
 # ══════════════════════════════════════════════
 
 @router.get("/health")
@@ -58,8 +56,8 @@ def health_check():
     return {"status": "ok", "nom_user_id": s.nom_user_id}
 
 
-@router.post("/login")
-def login(request: LoginRequest):
+@router.post("/auth/login")
+def auth_login(request: LoginRequest):
     if not request.username or not request.password:
         raise HTTPException(
             status_code=400,
@@ -87,64 +85,66 @@ def login(request: LoginRequest):
     }
 
 
-@router.post("/getResponseChat")
-def get_response_chat(request: ChatRequest):
-    """
-    Chat público. Respuesta simulada por ahora.
-    En Sprint 4 se conectará al RAG (Ollama + ChromaDB).
-    """
-    if not request.question:
+@router.post("/chat")
+def chat(request: ChatRequest, data_service: DataService = Depends(get_data_service)):
+    message = request.message.strip()
+    if not message:
         raise HTTPException(status_code=400, detail="La pregunta no puede estar vacía")
 
-    # TODO Sprint 4: integrar RAG aquí
+    try:
+        answer = data_service.answer_chat(message)
+    except ValueError as error:
+        logger.error("Error resolviendo chat: %s", error)
+        raise HTTPException(status_code=500, detail=str(error)) from error
+
     return {
-        "question": request.question,
-        "answer": random.choice(RESPUESTAS_SIMULADAS),
+        "message": message,
+        "answer": answer,
+    }
+
+
+@router.get("/dashboard/kpis")
+def get_dashboard_kpis(data_service: DataService = Depends(get_data_service)):
+    return data_service.dashboard_kpis()
+
+
+@router.get("/dashboard/series")
+def get_dashboard_series(data_service: DataService = Depends(get_data_service)):
+    return data_service.dashboard_series()
+
+
+# ══════════════════════════════════════════════
+# Endpoints legacy para no romper clientes antiguos
+# ══════════════════════════════════════════════
+
+@router.post("/login")
+def login_legacy(request: LoginRequest):
+    return auth_login(request)
+
+
+@router.post("/getResponseChat")
+def get_response_chat_legacy(request: ChatRequest, data_service: DataService = Depends(get_data_service)):
+    response = chat(request, data_service)
+    return {
+        "question": response["message"],
+        "answer": response["answer"],
     }
 
 
 @router.get("/getDatosDashboard")
-def get_datos_dashboard():
-    """
-    Dashboard KPIs. Intenta leer de RDS; si falla, devuelve datos demo.
-    """
-    try:
-        rows = fetch_all(
-            "SELECT periodo, ocupados_miles FROM empleo_deporte_trimestral "
-            "ORDER BY periodo DESC LIMIT 4"
-        )
-        if rows:
-            valores = [float(r["ocupados_miles"]) for r in rows]
-            ultimo = valores[0]
-            anterior = valores[-1] if len(valores) > 1 else ultimo
-            variacion = round((ultimo - anterior) / anterior * 100, 1) if anterior else 0
+def get_datos_dashboard_legacy(data_service: DataService = Depends(get_data_service)):
+    kpis = data_service.dashboard_kpis()
+    series = data_service.dashboard_series()
 
-            return {
-                "kpis": {
-                    "total_empleo_miles": ultimo,
-                    "variacion_anual_pct": variacion,
-                    "ratio_hombres_mujeres": 1.8,
-                },
-                "empleo_trimestral": [
-                    {"periodo": r["periodo"], "valor": float(r["ocupados_miles"])}
-                    for r in reversed(rows)
-                ],
-            }
-    except Exception as e:
-        logger.warning(f"RDS no disponible para dashboard, usando datos demo: {e}")
-
-    # Fallback: datos demo
     return {
         "kpis": {
-            "total_empleo_miles": 294.1,
-            "variacion_anual_pct": 3.2,
+            "total_empleo_miles": kpis["empleo_total"],
+            "variacion_anual_pct": kpis["growth_pct"],
             "ratio_hombres_mujeres": 1.8,
         },
         "empleo_trimestral": [
-            {"periodo": "2025-1T", "valor": 254.7},
-            {"periodo": "2025-2T", "valor": 246.9},
-            {"periodo": "2025-3T", "valor": 285.1},
-            {"periodo": "2025-4T", "valor": 294.1},
+            {"periodo": f"{item['year']}", "valor": item["value"]}
+            for item in series[-4:]
         ],
     }
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -2,7 +2,7 @@
 Schemas Pydantic — request/response models.
 """
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, ConfigDict
 
 
 class LoginRequest(BaseModel):
@@ -11,4 +11,6 @@ class LoginRequest(BaseModel):
 
 
 class ChatRequest(BaseModel):
-    question: str
+    model_config = ConfigDict(populate_by_name=True)
+
+    message: str = Field(min_length=1, alias="question")

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,33 +1,42 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { authApi } from '../services/api';
 
 type AuthContextValue = {
   isAuthenticated: boolean;
-  login: (username: string, password: string) => boolean;
+  login: (username: string, password: string) => Promise<boolean>;
   logout: () => void;
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
-const STORAGE_KEY = 'deportedata-admin-auth';
+const STORAGE_AUTH_KEY = 'deportedata-admin-auth';
+const STORAGE_TOKEN_KEY = 'deportedata-admin-token';
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
   useEffect(() => {
-    setIsAuthenticated(window.localStorage.getItem(STORAGE_KEY) === 'true');
+    const hasAuthFlag = window.localStorage.getItem(STORAGE_AUTH_KEY) === 'true';
+    const hasToken = Boolean(window.localStorage.getItem(STORAGE_TOKEN_KEY));
+    setIsAuthenticated(hasAuthFlag && hasToken);
   }, []);
 
   const value: AuthContextValue = {
     isAuthenticated,
-    login: (username, password) => {
+    login: async (username, password) => {
       const hasCredentials = username.trim().length > 0 && password.trim().length > 0;
-      if (hasCredentials) {
-        window.localStorage.setItem(STORAGE_KEY, 'true');
-        setIsAuthenticated(true);
+      if (!hasCredentials) {
+        return false;
       }
-      return hasCredentials;
+
+      const response = await authApi.login(username.trim(), password);
+      window.localStorage.setItem(STORAGE_AUTH_KEY, 'true');
+      window.localStorage.setItem(STORAGE_TOKEN_KEY, response.token);
+      setIsAuthenticated(true);
+      return true;
     },
     logout: () => {
-      window.localStorage.removeItem(STORAGE_KEY);
+      window.localStorage.removeItem(STORAGE_AUTH_KEY);
+      window.localStorage.removeItem(STORAGE_TOKEN_KEY);
       setIsAuthenticated(false);
     },
   };

--- a/frontend/src/pages/admin/LoginPage.tsx
+++ b/frontend/src/pages/admin/LoginPage.tsx
@@ -12,6 +12,7 @@ export function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const redirectTarget = (location.state as { from?: { pathname?: string } } | null)?.from?.pathname ?? '/admin';
 
@@ -19,15 +20,23 @@ export function LoginPage() {
     <Center mih="100vh" px="md">
       <Paper withBorder radius="xl" p="xl" maw={440} w="100%" className="glass-card">
         <form
-          onSubmit={(event) => {
+          onSubmit={async (event) => {
             event.preventDefault();
-            const success = login(username, password);
-            if (!success) {
-              setError('Introduce credenciales validas.');
-              return;
+            setIsSubmitting(true);
+            try {
+              const success = await login(username, password);
+              if (!success) {
+                setError('Introduce credenciales válidas.');
+                return;
+              }
+              setError(null);
+              navigate(redirectTarget, { replace: true });
+            } catch (err) {
+              const details = err instanceof Error ? err.message : 'Error desconocido';
+              setError(`No se pudo iniciar sesión contra el backend. ${details}`);
+            } finally {
+              setIsSubmitting(false);
             }
-            setError(null);
-            navigate(redirectTarget, { replace: true });
           }}
         >
           <Stack gap="md">
@@ -64,12 +73,12 @@ export function LoginPage() {
               </Text>
             ) : null}
 
-            <Button type="submit" fullWidth>
+            <Button type="submit" fullWidth loading={isSubmitting}>
               {t('signIn')}
             </Button>
 
             <Anchor component={Link} to="/">
-              Volver a la zona publica
+              Volver a la zona pública
             </Anchor>
           </Stack>
         </form>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -17,6 +17,13 @@ export type ChatResponse = {
   answer: string;
 };
 
+export type LoginResponse = {
+  name: string;
+  username: string;
+  role: string;
+  token: string;
+};
+
 const rawBaseUrl = import.meta.env.VITE_API_BASE_URL as string | undefined;
 const normalizedBaseUrl = rawBaseUrl?.replace(/\/+$/, '');
 
@@ -56,5 +63,13 @@ export const chatApi = {
     requestJson<ChatResponse>('/chat', {
       method: 'POST',
       body: JSON.stringify({ message }),
+    }),
+};
+
+export const authApi = {
+  login: (username: string, password: string) =>
+    requestJson<LoginResponse>('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ username, password }),
     }),
 };


### PR DESCRIPTION
### Motivation

- Unificar el contrato HTTP entre frontend y backend para que la UI consuma endpoints reales y no mocks.
- Habilitar autenticación desde la UI y persistencia de sesión para el área `admin`.
- Mantener compatibilidad con clientes legacy para evitar romper integraciones existentes.

### Description

- Añadidos endpoints públicos alineados con el frontend: `POST /auth/login`, `POST /chat`, `GET /dashboard/kpis` y `GET /dashboard/series` en `backend/app/api/routes_public.py` y mapeos legacy (`/login`, `/getResponseChat`, `/getDatosDashboard`).
- Conecté el `chat` con la lógica de negocio usando `DataService` (`app.services.data_service`) y manejé errores con `HTTPException` para respuestas consistentes.
- Modifiqué el esquema Pydantic `ChatRequest` en `backend/app/models.py` para aceptar `message` y mantener alias `question` (compatibilidad backwards) usando `Field` y `ConfigDict`.
- En frontend añadí `authApi.login` en `frontend/src/services/api.ts`, cambié `AuthContext` para realizar login real y guardar el `token` en `localStorage`, y actualicé `LoginPage` para soportar flujo asíncrono con estado de carga y manejo de errores.

### Testing

- Ejecuté `cd frontend && npm run build` y la compilación de producción de Vite/TypeScript terminó correctamente (build OK).
- Ejecuté `python -m compileall backend/app` para validar sintaxis del backend y la comprobación pasó sin errores (compilación OK).
- Intenté una prueba de integración con `TestClient` (`PYTHONPATH=. JWT_SECRET_KEY=test python - <<'PY' ... PY`) pero la ejecución quedó bloqueada por una dependencia faltante (`pydantic_settings`) en el entorno local, por lo que no se pudieron ejecutar los requests automatizados de `TestClient`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb455b53c83268580d14a92b490cc)